### PR TITLE
SWEEPR-20891: Updated GitHub Action versions to latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 11
@@ -23,7 +23,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: release notes
-      uses: release-drafter/release-drafter@v5
+      uses: release-drafter/release-drafter@v7
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
To support using Node24 as Node20 has become obsolete.